### PR TITLE
Add :dir options to process builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ user=> (-> (process ["ls"]) :out)
 "LICENSE\nREADME.md\nsrc\n"
 ```
 
+Invoke `ls` for different directory than current directory:
+
+``` clojure
+user=> (-> (process ["ls"] {:dir "test/babashka"}) :out)
+"process_test.clj\n"
+```
+
 Output as stream:
 
 ``` clojure

--- a/test/babashka/process_test.clj
+++ b/test/babashka/process_test.clj
@@ -23,4 +23,11 @@
   (testing "chaining"
     (is (= "README.md\n"
            (-> (process ["ls"])
-               (process ["grep" "README"]) :out)))))
+               (process ["grep" "README"]) :out))))
+  (testing "use of :dir options"
+    (is (= (-> (process ["ls"]) :out)
+           (-> (process ["ls"] {:dir "."}) :out)))
+    (is (= (-> (process ["ls"] {:dir "test/babashka"}) :out)
+           "process_test.clj\n"))
+    (is (not= (-> (process ["ls"]) :out)
+              (-> (process ["ls"] {:dir "test/babashka"}) :out)))))


### PR DESCRIPTION
Thanks for starting Babashka project.
I like to add the option :dir so that the `process` function can be called from different directory.
Thanks