### PR TITLE
feat: enable dispatch of errors based on ex-data type

### DIFF
--- a/src/babashka/process.clj
+++ b/src/babashka/process.clj
@@ -80,7 +80,9 @@
                 (not (zero? exit)))
              (throw (ex-info
                       (if (string? err) err "failed")
-                      (assoc res :args args)))
+                      (assoc res
+                             :args args
+                             :type ::error)))
              res))
          res)))))
 

--- a/test/babashka/process_test.clj
+++ b/test/babashka/process_test.clj
@@ -55,9 +55,12 @@
           clojure.lang.ExceptionInfo #"failed"
           (process ["clojure" "-e" (str '(System/exit 1))] {:throw true :err :inherit}))
         "With no :err string")
-    (testing "and the exception contains the process arguments"
+    (testing "and the exception"
       (let [args ["clojure" "-e" (str '(System/exit 1))]]
         (try
           (process args {:throw true :err :inherit})
           (catch clojure.lang.ExceptionInfo e
-            (is (= args (:args (ex-data e))))))))))
+            (testing "contains the process arguments"
+              (is (= args (:args (ex-data e)))))
+            (testing "and contains a babashka process type"
+              (is (= :babashka.process/error (:type (ex-data e)))))))))))


### PR DESCRIPTION
Add `:type :babashka.process/error` to the data of the exception thrown
on non-zero exit.